### PR TITLE
Allow reading test files from a jar file

### DIFF
--- a/slt
+++ b/slt
@@ -45,6 +45,8 @@ if [ "$cygwin" ]; then
   CP=$(cygpath -wp "$CP")
 fi
 
-exec java $VM_OPTS -cp "${CP}" net.hydromatic.sqllogictest.Main "$@"
+#exec java $VM_OPTS -cp "${CP}" net.hydromatic.sqllogictest.Main "$@"
+# TODO: how to programmatically get the jar name?
+exec java -classpath target/sql-logic-test-0.2-SNAPSHOT.jar net.hydromatic.sqllogictest.Main "$@"
 
 # End slt

--- a/src/main/java/net/hydromatic/sqllogictest/SltTestFile.java
+++ b/src/main/java/net/hydromatic/sqllogictest/SltTestFile.java
@@ -27,9 +27,11 @@ import net.hydromatic.sqllogictest.util.Utilities;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -103,12 +105,13 @@ public class SltTestFile {
   /**
    * Create a test file from the file with the specified name.
    */
-  public SltTestFile(String testFile) throws IOException {
-    File file = new File(testFile);
-    this.reader = new BufferedReader(new FileReader(file));
+  public SltTestFile(Path path) throws IOException {
+    byte[] bytes = Files.readAllBytes(path);
+    this.reader = new BufferedReader(new InputStreamReader(
+            new ByteArrayInputStream(bytes)));
     this.fileContents = new ArrayList<>();
     this.lineNo = 0;
-    this.testFile = testFile;
+    this.testFile = path.toString();
     this.done = false;
     this.testCount = 0;
   }

--- a/src/main/java/net/hydromatic/sqllogictest/TestLoader.java
+++ b/src/main/java/net/hydromatic/sqllogictest/TestLoader.java
@@ -78,11 +78,12 @@ public class TestLoader extends SimpleFileVisitor<Path> {
       SltTestFile test = null;
       try {
         options.message("Running " + file, 1);
-        test = new SltTestFile(file.toString());
+        test = new SltTestFile(file);
         test.parse(options);
       } catch (Exception ex) {
-        options.err.println("Error while executing test " + file + ": "
-            + ex.getMessage());
+        String errMsg = "Error while executing test " + file + ": "
+                + ex.getMessage();
+        options.err.println(errMsg);
         this.fileParseErrors++;
       }
       if (test != null) {

--- a/src/test/java/net/hydromatic/sqllogictest/SqlLogicTestTest.java
+++ b/src/test/java/net/hydromatic/sqllogictest/SqlLogicTestTest.java
@@ -171,7 +171,8 @@ public class SqlLogicTestTest {
         ByteArrayOutputStream berr = new ByteArrayOutputStream()) {
       final PrintStream out = new PrintStream(bout);
       final PrintStream err = new PrintStream(berr);
-      Main.execute(false, out, err, args);
+      ExecutionOptions options = new ExecutionOptions(false, out, err);
+      Main.execute(options, args);
       out.flush();
       err.flush();
       return new Output(bout.toString(UTF_8), berr.toString(UTF_8));


### PR DESCRIPTION
This also changes the API to the Main.execute function to take ExecutionOptions as an argument. 
This makes it possible to register new executors prior to invoking "execute".