### PR TITLE
NoSuchFileException when calling Main from jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@ SOFTWARE.
     <junit-jupiter.version>5.9.3</junit-jupiter.version>
     <maven-checkstyle-plugin.version>3.2.2</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
     <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
@@ -98,6 +99,7 @@ SOFTWARE.
     <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>3.1.0</maven-failsafe-plugin.version>
     <postgresql.version>42.6.0</postgresql.version>
   </properties>
 
@@ -200,6 +202,21 @@ SOFTWARE.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <version>${maven-site-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven-dependency-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>build-classpath</goal>
+            </goals>
+            <configuration>
+              <outputProperty>maven.compile.classpath</outputProperty>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -370,6 +387,26 @@ SOFTWARE.
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <useManifestOnlyJar>false</useManifestOnlyJar>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-failsafe-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <systemPropertyVariables>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <artifactName>${project.build.finalName}.jar</artifactName>
+            <buildClasspath>${maven.compile.classpath}</buildClasspath>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@ SOFTWARE.
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>3.1.0</maven-failsafe-plugin.version>
     <postgresql.version>42.6.0</postgresql.version>
+    <reflections.version>0.10.2</reflections.version>
   </properties>
 
   <!-- Environment settings. -->
@@ -178,6 +179,11 @@ SOFTWARE.
       <version>${postgresql.version}</version>
       <scope>runtime</scope>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>${reflections.version}</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/net/hydromatic/sqllogictest/ExecutionOptions.java
+++ b/src/main/java/net/hydromatic/sqllogictest/ExecutionOptions.java
@@ -132,7 +132,7 @@ public class ExecutionOptions {
    */
   public List<String> getDirectories() {
     if (this.directories.isEmpty()) {
-      this.directories.add(".");  // This means "everything"
+      this.directories.add("test");  // This means "everything"
     }
     return this.directories;
   }

--- a/src/main/java/net/hydromatic/sqllogictest/SltTestFile.java
+++ b/src/main/java/net/hydromatic/sqllogictest/SltTestFile.java
@@ -27,9 +27,9 @@ import net.hydromatic.sqllogictest.util.Utilities;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -104,8 +104,9 @@ public class SltTestFile {
    * Create a test file from the file with the specified name.
    */
   public SltTestFile(String testFile) throws IOException {
-    File file = new File(testFile);
-    this.reader = new BufferedReader(new FileReader(file));
+    ClassLoader clLoader = Thread.currentThread().getContextClassLoader();
+    InputStream is = clLoader.getResourceAsStream(testFile);
+    this.reader = new BufferedReader(new InputStreamReader(is));
     this.fileContents = new ArrayList<>();
     this.lineNo = 0;
     this.testFile = testFile;

--- a/src/test/java/net/hydromatic/sqllogictest/ITestRunWithJars.java
+++ b/src/test/java/net/hydromatic/sqllogictest/ITestRunWithJars.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.hydromatic.sqllogictest;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Integration test for verifying scenarios using the produced jars.
+ *
+ * <p>The test is skipped when run from IDE cause the required System properties
+ * are only set in maven.</p>
+ */
+public class ITestRunWithJars {
+  private static final String BUILD_DIR = System.getProperty("buildDirectory");
+  private static final String ARTIFACT = System.getProperty("artifactName");
+  private static final String CLASSPATH = System.getProperty("buildClasspath");
+
+  @Test void testRunSingleTestNoException()
+      throws IOException, InterruptedException {
+    Output r = runMain("-e", "none", "select1.test");
+    assertThat(r.err, not(containsString("Exception")));
+  }
+
+  private static Output runMain(String... args)
+      throws IOException, InterruptedException {
+    Assumptions.assumeFalse(BUILD_DIR == null);
+    Assumptions.assumeFalse(ARTIFACT == null);
+    Assumptions.assumeFalse(CLASSPATH == null);
+    String jarPath = Paths.get(BUILD_DIR, ARTIFACT).toString();
+    String classPath = jarPath + ":" + CLASSPATH;
+    List<String> cmd = new ArrayList<>();
+    cmd.add("java");
+    cmd.add("-cp");
+    cmd.add(classPath);
+    cmd.add("net.hydromatic.sqllogictest.Main");
+    cmd.addAll(Arrays.asList(args));
+    Process p = new ProcessBuilder(cmd).start();
+    p.waitFor();
+    return new Output(readAllLines(p.getInputStream()),
+        readAllLines(p.getErrorStream()));
+  }
+
+  private static String readAllLines(InputStream is) {
+    return new BufferedReader(new InputStreamReader(is)).lines()
+        .collect(Collectors.joining(System.lineSeparator()));
+  }
+
+  private static class Output {
+    final String out;
+    final String err;
+
+    Output(String out, String err) {
+      this.out = out;
+      this.err = err;
+    }
+  }
+}


### PR DESCRIPTION
When we are running the sqllogictest using the jar(s) and not the classes under target directory we cannot read back the test file resources cause the file is no longer in the local file system but inside the jar and the classic file walker cannot operate as usual.
```
java -classpath target/sql-logic-test-0.2-SNAPSHOT.jar net.hydromatic.sqllogictest.Main -e none select1.test
    java.nio.file.NoSuchFileException: file:/home/stamatis/.m2/repository/net/hydromatic/sql-logic-test/0.2/sql-logic-test-0.2.jar!/test/select1.test
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
        at sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
        at sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:144)
        at sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)
        at java.nio.file.Files.readAttributes(Files.java:1737)
        at java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:219)
        at java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:276)
        at java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:322)
        at java.nio.file.Files.walkFileTree(Files.java:2662)
        at java.nio.file.Files.walkFileTree(Files.java:2742)
        at net.hydromatic.sqllogictest.Main.execute(Main.java:69)
```
https://github.com/hydromatic/sql-logic-test/commit/7416bc1fa3177e1989ecdfb034cc7b6807a1f495 adds an integration test reproducing the problem. 
https://github.com/hydromatic/sql-logic-test/commit/ff8b354fff298d76ca0466f3fb09b26a2f25e31f avoids the file-system traversal by getting test resources using the `org.reflections:reflections` library and reads them using ClassLoader#getResourceAsStream method which is file-system agnostic.